### PR TITLE
fix import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
     packages=find_packages(exclude='sample'),
     keywords=package_info.__keywords__,
     zip_safe=False,
-    install_requires=['numpy>=1.22.0'],
+    install_requires=['numpy>=1.22.0', 'loky'],
     python_requires='>=3.7, <3.11'
 )


### PR DESCRIPTION
When I import this package, I get an error.

```sh
$ git clone https://github.com/recruit-tech/codable-model-optimizer.git
$ cd codable-model-optimizer
$ python setup.py install
$ python -c "import codableopt"

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/hogehoge/codable-model-optimizer/codableopt/__init__.py", line 3, in <module>
    from codableopt.solver.opt_solver import OptSolver
  File "/hogehoge/codable-model-optimizer/codableopt/solver/opt_solver.py", line 20, in <module>
    from codableopt.solver.optimizer.optimization_solver import OptimizationSolver
  File "/hogehoge/codable-model-optimizer/codableopt/solver/optimizer/optimization_solver.py", line 21, in <module>
    from loky import get_reusable_executor
ModuleNotFoundError: No module named 'loky'
```

So, I added "loky" to the install_requires in setup.py.